### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/shubham-skillbook/8d36a79c-2d67-45ad-9fd1-1fe0502adcbf/199911c3-9d4e-4fce-8633-ec058d636cce/_apis/work/boardbadge/e5876963-a012-4aa0-ad9d-9e33e57fe0e0)](https://dev.azure.com/shubham-skillbook/8d36a79c-2d67-45ad-9fd1-1fe0502adcbf/_boards/board/t/199911c3-9d4e-4fce-8633-ec058d636cce/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.